### PR TITLE
fix(TreeList): delete loaded map cache

### DIFF
--- a/src/components/groups/groupTree/TreeList.jsx
+++ b/src/components/groups/groupTree/TreeList.jsx
@@ -99,13 +99,8 @@ const TreeList = (props) => {
     itemHeight = '44px',
   } = props;
 
-  const loadedMap = useRef({});
-
   const handleLoad = id => {
-    if (!loadedMap.current[id] && loadData) {
-      loadedMap.current[id] = true;
-      loadData(id);
-    }
+    loadData(id);
   };
  
   return (


### PR DESCRIPTION
the component no longer prevents the action to fire again after the
first time.